### PR TITLE
Add Jest tests for utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Calculates the area of non-white space in a set of images",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -30,5 +30,8 @@
     "jimp": "^0.2.28",
     "progress-bar-formatter": "^2.0.1",
     "update-notifier": "^2.3.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/test/process_image.test.js
+++ b/test/process_image.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function createFakeImage() {
+  const width = 1;
+  const height = 1;
+  const data = Buffer.from([100, 100, 100, 255]);
+  return {
+    bitmap: { width, height, data },
+    scan: function(sx, sy, w, h, cb) {
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          const idx = (width * y + x) * 4;
+          cb.call(this, x, y, idx);
+        }
+      }
+    },
+    setPixelColor() {},
+    write: function(p, cb) { fs.writeFileSync(p, ''); cb(); }
+  };
+}
+
+jest.mock('jimp', () => {
+  const fakeImg = createFakeImage();
+  return {
+    read: jest.fn(() => Promise.resolve(fakeImg)),
+    rgbaToInt: () => 0
+  };
+});
+
+const processImage = require('../lib/process_image');
+
+describe('process_image', () => {
+  test('counts dark pixels in image', async () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'pimg-'));
+    global.ROOT_DIR = tmpdir;
+    fs.mkdirSync(path.join(tmpdir, 'nonwhitearea_output'), { recursive: true });
+    const settings = { ml: 0, mr: 0, mt: 0, mb: 0, minBright: 128 };
+    const count = await processImage('dummy', settings, 'out.png');
+    expect(count).toBe(1);
+    expect(fs.existsSync(path.join(tmpdir, 'nonwhitearea_output', 'out.png'))).toBe(true);
+    fs.rmSync(tmpdir, { recursive: true, force: true });
+  });
+});

--- a/test/walkDir.test.js
+++ b/test/walkDir.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+require('../walkDir');
+
+describe('walkDirectory', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'walkdir-'));
+    fs.writeFileSync(path.join(tmpDir, 'root.txt'), 'root');
+    fs.mkdirSync(path.join(tmpDir, 'sub'));
+    fs.writeFileSync(path.join(tmpDir, 'sub', 'subfile.txt'), 'sub');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('depth 1 returns top level entries', () => {
+    const files = global.walkDirectory(tmpDir, '', 1).sort();
+    expect(files).toEqual(['/root.txt', '/sub'].sort());
+  });
+
+  test('depth 2 returns nested files', () => {
+    const files = global.walkDirectory(tmpDir, '', 2).sort();
+    expect(files).toEqual(['/root.txt', '/sub/subfile.txt'].sort());
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and wire `npm test` script
- test directory traversal in `walkDirectory`
- test pixel counting in `process_image`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684829f75ab0832cbb8c99631e1700f7