### PR TITLE
Remove fs-extra usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const pkg = require('./package.json');
 const updateNotifier = require('update-notifier')({pkg});
 const c = require('chalk');
 const i = require('inquirer');
-const fs = require("fs-extra");
+const fs = require('fs');
 const jimp = require("jimp");
 var prog = require('progress-bar-formatter');
 const walkDirectory = require(path.join(__dirname, 'walkDir.js'));
@@ -104,7 +104,10 @@ function main_menu() {
                                     }
                                     processNextImg().then(function(){
                                         console.log(c.green("\n\n All files processed!"));
-                                        fs.writeJsonSync(path.join(context.rootDir, 'nonwhitearea.json'), arearesults);
+                                        fs.writeFileSync(
+                                            path.join(context.rootDir, 'nonwhitearea.json'),
+                                            JSON.stringify(arearesults, null, 2)
+                                        );
                                         setTimeout(main_menu, 5000);
                                     });
                                 }else{

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "fs-extra": "^10.1.0",
     "inquirer": "^8.2.5",
     "jimp": "^0.22.10",
     "progress-bar-formatter": "^2.0.1",


### PR DESCRIPTION
## Summary
- swap `fs-extra` for Node's built-in `fs` in CLI
- delete `fs-extra` dependency

## Testing
- `npm test` *(fails: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684835a76640832cb85a5b4449cfb176